### PR TITLE
Fix #3: Add Category and command for wizard creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # papyrus_anatomy
-An example of a simple Papyrus DSML in the form of an antomy
+An example of a simple [Papyrus][1] DSML in the form of an anatomy
 
+
+
+[1]: https://eclipse.org/papyrus/

--- a/org.eclipse.papyrus.tutorial.anatomy/META-INF/MANIFEST.MF
+++ b/org.eclipse.papyrus.tutorial.anatomy/META-INF/MANIFEST.MF
@@ -10,4 +10,5 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.gmf.runtime.emf.type.core;bundle-version="1.9.0",
  org.eclipse.papyrus.infra.types.core,
  org.eclipse.papyrus.infra.newchild,
- org.eclipse.papyrus.infra.viewpoints.policy
+ org.eclipse.papyrus.infra.viewpoints.policy,
+ org.eclipse.papyrus.uml.diagram.common;bundle-version="2.0.0"

--- a/org.eclipse.papyrus.tutorial.anatomy/plugin.xml
+++ b/org.eclipse.papyrus.tutorial.anatomy/plugin.xml
@@ -67,4 +67,16 @@
     </configuration>
  </extension>
 
+
+    <extension point="org.eclipse.papyrus.infra.ui.papyrusDiagram">
+	     <diagramCategory
+	            class="org.eclipse.papyrus.tutorial.anatomy.types.commands.CreateAnatomyModelCommand"
+	            description="Anatomy diagrams"
+	            icon="platform:/plugin/org.eclipse.papyrus.tutorial.anatomy/icons/anatomy.png"
+	            id="Anatomy Category"
+	            label="Anatomy Category">
+	     </diagramCategory>
+    </extension>
+
+
 </plugin>

--- a/org.eclipse.papyrus.tutorial.anatomy/src/org/eclipse/papyrus/tutorial/anatomy/types/commands/CreateAnatomyModelCommand.java
+++ b/org.eclipse.papyrus.tutorial.anatomy/src/org/eclipse/papyrus/tutorial/anatomy/types/commands/CreateAnatomyModelCommand.java
@@ -1,0 +1,49 @@
+package org.eclipse.papyrus.tutorial.anatomy.types.commands;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.diagram.common.commands.ModelCreationCommandBase;
+import org.eclipse.papyrus.uml.tools.utils.PackageUtil;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.PackageImport;
+import org.eclipse.uml2.uml.Profile;
+import org.eclipse.uml2.uml.UMLFactory;
+import org.eclipse.uml2.uml.resource.UMLResource;
+
+
+/**
+ * The Class create an anatomy model.
+ */
+public class CreateAnatomyModelCommand extends ModelCreationCommandBase {
+
+	/**
+	 * @see org.eclipse.papyrus.infra.core.extension.commands.ModelCreationCommandBase#createRootElement()
+	 *
+	 * @return
+	 */
+
+	@Override
+	protected EObject createRootElement() {
+		return UMLFactory.eINSTANCE.createModel();
+	}
+
+	/**
+	 * A standard anatomy model should have the anatomy profile
+	 * 
+	 * @see org.eclipse.papyrus.infra.core.extension.commands.ModelCreationCommandBase#initializeModel(org.eclipse.emf.ecore.EObject)
+	 *
+	 * @param owner
+	 */
+
+	@Override
+	protected void initializeModel(EObject owner) {
+		super.initializeModel(owner);
+		Package packageOwner = (Package) owner;
+		Profile anatomyProfile = (Profile) PackageUtil.loadPackage(URI.createURI("pathmap://ANATOMY_PROFILE/anatomy.profile.uml"), owner.eResource().getResourceSet());
+		if (anatomyProfile != null) {
+			PackageUtil.applyProfile(packageOwner, anatomyProfile, true);
+		}	
+
+	}
+
+}


### PR DESCRIPTION
- declare the extension point
- create the command to init the model
  => it will :
  - make the category present in the New Model Wizard
  - allow to create the custom diagrams with the wizard
  - some typo in Readme

Signed-off-by: Benoit maggi benoit.maggi@cea.fr
