### PR TITLE
Create a WorkItem

### DIFF
--- a/org.eclipse.papyrus.tutorial.anatomy/plugin.xml
+++ b/org.eclipse.papyrus.tutorial.anatomy/plugin.xml
@@ -44,7 +44,22 @@
           path="types/anatomy.diagram.elementtypesconfigurations">
     </elementTypeSet>
  </extension>
+
+ <extension
+       point="org.eclipse.papyrus.infra.types.core.elementTypeSetConfiguration">
+    <elementTypeSet
+          clientContextID="org.eclipse.papyrus.infra.services.edit.TypeContext"
+          path="types/anatomy-gen.elementtypesconfigurations">
+    </elementTypeSet>
+ </extension>
  
+  <extension
+       point="org.eclipse.papyrus.infra.types.core.elementTypeSetConfiguration">
+    <elementTypeSet
+          clientContextID="org.eclipse.papyrus.infra.services.edit.TypeContext"
+          path="types/anatomydi-gen.elementtypesconfigurations">
+    </elementTypeSet>
+ </extension> 
  <extension
        point="org.eclipse.papyrus.infra.newchild">
     <menuCreationModel
@@ -85,4 +100,8 @@
             genModel="profiles/anatomy.genmodel"/>
    </extension>
 
+  <extension point="org.eclipse.uml2.uml.generated_package">
+     <profile uri="http://www.eclipse.org/papyrus/Anatomy"
+           location="pathmap://ANATOMY_PROFILE/anatomy.profile.uml#_pWlLsBzSEeaUCNZJoDLoVw"/>
+  </extension>  
 </plugin>

--- a/org.eclipse.papyrus.tutorial.anatomy/src/org/eclipse/papyrus/tutorial/anatomy/types/advices/WorkItemAdvice.java
+++ b/org.eclipse.papyrus.tutorial.anatomy/src/org/eclipse/papyrus/tutorial/anatomy/types/advices/WorkItemAdvice.java
@@ -8,12 +8,12 @@ import org.eclipse.gmf.runtime.emf.type.core.commands.ConfigureElementCommand;
 import org.eclipse.gmf.runtime.emf.type.core.edithelper.AbstractEditHelperAdvice;
 import org.eclipse.gmf.runtime.emf.type.core.requests.ConfigureRequest;
 import org.eclipse.uml2.uml.Element;
-import org.eclipse.uml2.uml.Stereotype;
+import org.eclipse.uml2.uml.util.UMLUtil;
+
+import Anatomy.Type;
+import Anatomy.WorkPart;
 
 public class WorkItemAdvice extends AbstractEditHelperAdvice {
-	private static final String STEREOTYPE_PROPERTY__TYPE_VALUE = "WorkItem";
-	private static final String STEREOTYPE_PROPERTY__TYPE = "type";
-	private static final String ANATOMY_WORK_PART = "Anatomy::WorkPart";
 
 	@Override
 	protected org.eclipse.gmf.runtime.common.core.command.ICommand getAfterConfigureCommand(final ConfigureRequest request) {
@@ -21,15 +21,11 @@ public class WorkItemAdvice extends AbstractEditHelperAdvice {
 		return new ConfigureElementCommand(request) {
 			@Override
 			protected CommandResult doExecuteWithResult(IProgressMonitor progressMonitor, IAdaptable info) throws ExecutionException {
-				if (clazz.getAppliedStereotype(ANATOMY_WORK_PART) == null) {
-					Stereotype stereotype = clazz.getApplicableStereotype(ANATOMY_WORK_PART);
-					if (stereotype != null) {
-						clazz.applyStereotype(stereotype);
-						clazz.setValue(stereotype, STEREOTYPE_PROPERTY__TYPE, STEREOTYPE_PROPERTY__TYPE_VALUE);			    	  
-					}
-				}
+				 WorkPart stereotypeApplication = UMLUtil.getStereotypeApplication(clazz, WorkPart.class);
+				 stereotypeApplication.setType(Type.WORK_ITEM);
 				return CommandResult.newOKCommandResult(clazz);
 			}
 		};
 	}
+	
 }

--- a/org.eclipse.papyrus.tutorial.anatomy/types/anatomy-gen.elementtypesconfigurations
+++ b/org.eclipse.papyrus.tutorial.anatomy/types/anatomy-gen.elementtypesconfigurations
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="ASCII"?>
+<elementtypesconfigurations:ElementTypeSetConfiguration xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:applystereotypeadvice="http://www.eclipse.org/papyrus/uml/types/applystereotypeadvice/1.1" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.1" xmlns:stereotypematcher="http://www.eclipse.org/papyrus/uml/types/stereotypematcher/1.1" identifier="org.eclipse.papyrus.tutorial.anatomy.elementTypes" metamodelNsURI="http://www.eclipse.org/uml2/5.0.0/UML">
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.Blocks_UML::Association" name="Blocks" hint="UML::Association">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.uml.Association</specializedTypesID>
+    <matcherConfiguration xsi:type="stereotypematcher:StereotypeApplicationMatcherConfiguration">
+      <stereotypesQualifiedNames>Anatomy::Blocks</stereotypesQualifiedNames>
+    </matcherConfiguration>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.Relationship_UML::Association" name="Relationship" hint="UML::Association">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.uml.Association</specializedTypesID>
+    <matcherConfiguration xsi:type="stereotypematcher:StereotypeApplicationMatcherConfiguration">
+      <stereotypesQualifiedNames>Anatomy::Relationship</stereotypesQualifiedNames>
+    </matcherConfiguration>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.WorkPart" name="WorkPart" hint="UML::Class">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.uml.Class</specializedTypesID>
+    <matcherConfiguration xsi:type="stereotypematcher:StereotypeApplicationMatcherConfiguration">
+      <stereotypesQualifiedNames>Anatomy::WorkPart</stereotypesQualifiedNames>
+    </matcherConfiguration>
+  </elementTypeConfigurations>
+  <adviceBindingsConfigurations xsi:type="applystereotypeadvice:ApplyStereotypeAdviceConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.blocks_UML::Association" target="//@elementTypeConfigurations.0">
+    <stereotypesToApply stereotypeQualifiedName="Anatomy::Blocks" updateName="true">
+      <requiredProfiles>Anatomy</requiredProfiles>
+    </stereotypesToApply>
+  </adviceBindingsConfigurations>
+  <adviceBindingsConfigurations xsi:type="applystereotypeadvice:ApplyStereotypeAdviceConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.relationship_UML::Association" target="//@elementTypeConfigurations.1">
+    <stereotypesToApply stereotypeQualifiedName="Anatomy::Relationship" updateName="true">
+      <requiredProfiles>Anatomy</requiredProfiles>
+    </stereotypesToApply>
+  </adviceBindingsConfigurations>
+  <adviceBindingsConfigurations xsi:type="applystereotypeadvice:ApplyStereotypeAdviceConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomy.workPart" target="//@elementTypeConfigurations.2">
+    <stereotypesToApply stereotypeQualifiedName="Anatomy::WorkPart" updateName="true">
+      <requiredProfiles>Anatomy</requiredProfiles>
+    </stereotypesToApply>
+  </adviceBindingsConfigurations>
+</elementtypesconfigurations:ElementTypeSetConfiguration>

--- a/org.eclipse.papyrus.tutorial.anatomy/types/anatomy.elementtypesconfigurations
+++ b/org.eclipse.papyrus.tutorial.anatomy/types/anatomy.elementtypesconfigurations
@@ -1,31 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<elementtypesconfigurations:ElementTypeSetConfiguration xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:applystereotypeadvice="http://www.eclipse.org/papyrus/uml/types/applystereotypeadvice/1.1" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.1" xmlns:stereotypematcher="http://www.eclipse.org/papyrus/uml/types/stereotypematcher/1.1" xmi:id="_3mYnYBzUEeaUCNZJoDLoVw" description="The Element Types of the Anatomy Language" identifier="org.eclipse.papyrus.tutorial.anatomy.types" name="Anatomy Element Types" metamodelNsURI="http://www.eclipse.org/uml2/5.0.0/UML">
-  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_FcKrcBzVEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.bugzilla" name="Bugzilla" hint="bugzilla">
-    <specializedTypesID>org.eclipse.papyrus.uml.Class</specializedTypesID>
+<elementtypesconfigurations:ElementTypeSetConfiguration xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.1" xmi:id="_3mYnYBzUEeaUCNZJoDLoVw" description="The Element Types of the Anatomy Language" identifier="org.eclipse.papyrus.tutorial.anatomy.types" name="Anatomy Element Types" metamodelNsURI="http://www.eclipse.org/uml2/5.0.0/UML">
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_FcKrcBzVEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.bugzilla" name="Bugzilla" hint="UML::Class">
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
     <editHelperAdviceConfiguration xsi:type="elementtypesconfigurations:EditHelperAdviceConfiguration" xmi:id="_zSvygBzVEeaUCNZJoDLoVw" description="" editHelperAdviceClassName="org.eclipse.papyrus.tutorial.anatomy.types.advices.BugzillaAdvice"/>
     <matcherConfiguration xsi:type="elementtypesconfigurations:MatcherConfiguration" xmi:id="_L2bZIBzVEeaUCNZJoDLoVw" matcherClassName="org.eclipse.papyrus.tutorial.anatomy.types.matchers.BugzillaMatcher"/>
   </elementTypeConfigurations>
-  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_ll_5MBzWEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.workitem" name="WorkItem" hint="workitem">
-    <specializedTypesID>org.eclipse.papyrus.uml.Class</specializedTypesID>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_ll_5MBzWEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.workitem" name="WorkItem" hint="UML::Class">
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
     <editHelperAdviceConfiguration xsi:type="elementtypesconfigurations:EditHelperAdviceConfiguration" xmi:id="_ll_5MRzWEeaUCNZJoDLoVw" description="" editHelperAdviceClassName="org.eclipse.papyrus.tutorial.anatomy.types.advices.WorkItemAdvice"/>
     <matcherConfiguration xsi:type="elementtypesconfigurations:MatcherConfiguration" xmi:id="_ll_5MhzWEeaUCNZJoDLoVw" matcherClassName="org.eclipse.papyrus.tutorial.anatomy.types.matchers.WorkItemMatcher"/>
   </elementTypeConfigurations>
-  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_oCNLABzYEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.blocks" name="Blocks" hint="blocks">
-    <specializedTypesID>org.eclipse.papyrus.uml.Association</specializedTypesID>
-    <matcherConfiguration xsi:type="stereotypematcher:StereotypeApplicationMatcherConfiguration" xmi:id="_zFRP0BzYEeaUCNZJoDLoVw">
-      <stereotypesQualifiedNames>Anatomy::Blocks</stereotypesQualifiedNames>
-    </matcherConfiguration>
-  </elementTypeConfigurations>
-  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" xmi:id="_IcGJ0BzhEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.relationship" name="Relationship" hint="relationship">
-    <specializedTypesID>org.eclipse.papyrus.uml.Association</specializedTypesID>
-    <matcherConfiguration xsi:type="stereotypematcher:StereotypeApplicationMatcherConfiguration" xmi:id="_IcGJ0RzhEeaUCNZJoDLoVw">
-      <stereotypesQualifiedNames>Anatomy::Relationship</stereotypesQualifiedNames>
-    </matcherConfiguration>
-  </elementTypeConfigurations>
-  <adviceBindingsConfigurations xsi:type="applystereotypeadvice:ApplyStereotypeAdviceConfiguration" xmi:id="_12R-4BzYEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.blocks.sterotypeAdvice" target="_oCNLABzYEeaUCNZJoDLoVw">
-    <stereotypesToApply xmi:id="_2ezXcBzYEeaUCNZJoDLoVw" stereotypeQualifiedName="Anatomy::Blocks"/>
-  </adviceBindingsConfigurations>
-  <adviceBindingsConfigurations xsi:type="applystereotypeadvice:ApplyStereotypeAdviceConfiguration" xmi:id="_Jtb14BzhEeaUCNZJoDLoVw" identifier="org.eclipse.papyrus.tutorial.anatomy.types.relationship.sterotypeAdvice" target="_IcGJ0BzhEeaUCNZJoDLoVw">
-    <stereotypesToApply xmi:id="_Jtb14RzhEeaUCNZJoDLoVw" stereotypeQualifiedName="Anatomy::Relationship" updateName="true"/>
-  </adviceBindingsConfigurations>
 </elementtypesconfigurations:ElementTypeSetConfiguration>

--- a/org.eclipse.papyrus.tutorial.anatomy/types/anatomydi-gen.elementtypesconfigurations
+++ b/org.eclipse.papyrus.tutorial.anatomy/types/anatomydi-gen.elementtypesconfigurations
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="ASCII"?>
+<elementtypesconfigurations:ElementTypeSetConfiguration xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.1" identifier="org.eclipse.papyrus.tutorial.anatomydi.elementTypes" metamodelNsURI="http://www.eclipse.org/uml2/5.0.0/UML">
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Blocks_Association_BranchEdge" name="Blocks (Association_BranchEdge)" hint="Association_BranchEdge">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Blocks_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_BranchEdge</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Blocks_Association_Edge" name="Blocks (Association_Edge)" hint="Association_Edge">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Blocks_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Edge</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Blocks_Association_Shape" name="Blocks (Association_Shape)" hint="Association_Shape">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Blocks_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Shape</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Blocks_Association_Shape_CN" name="Blocks (Association_Shape_CN)" hint="Association_Shape_CN">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Blocks_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Shape_CN</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Relationship_Association_BranchEdge" name="Relationship (Association_BranchEdge)" hint="Association_BranchEdge">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Relationship_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_BranchEdge</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Relationship_Association_Edge" name="Relationship (Association_Edge)" hint="Association_Edge">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Relationship_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Edge</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Relationship_Association_Shape" name="Relationship (Association_Shape)" hint="Association_Shape">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Relationship_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Shape</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.Relationship_Association_Shape_CN" name="Relationship (Association_Shape_CN)" hint="Association_Shape_CN">
+    <iconEntry iconPath="/icons/full/obj16/Association.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.Relationship_UML::Association</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Association_Shape_CN</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.WorkPart_Class_MetaclassShape" name="WorkPart (Class_MetaclassShape)" hint="Class_MetaclassShape">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Class_MetaclassShape</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.WorkPart_Class_MetaclassShape_CN" name="WorkPart (Class_MetaclassShape_CN)" hint="Class_MetaclassShape_CN">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Class_MetaclassShape_CN</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.WorkPart_Class_NestedClassifierLabel" name="WorkPart (Class_NestedClassifierLabel)" hint="Class_NestedClassifierLabel">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Class_NestedClassifierLabel</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.WorkPart_Class_Shape" name="WorkPart (Class_Shape)" hint="Class_Shape">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Class_Shape</specializedTypesID>
+  </elementTypeConfigurations>
+  <elementTypeConfigurations xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" identifier="org.eclipse.papyrus.tutorial.anatomydi.WorkPart_Class_Shape_CN" name="WorkPart (Class_Shape_CN)" hint="Class_Shape_CN">
+    <iconEntry iconPath="/icons/full/obj16/Class.gif" bundleId="org.eclipse.uml2.uml.edit"/>
+    <specializedTypesID>org.eclipse.papyrus.tutorial.anatomy.WorkPart</specializedTypesID>
+    <specializedTypesID>org.eclipse.papyrus.umldi.Class_Shape_CN</specializedTypesID>
+  </elementTypeConfigurations>
+</elementtypesconfigurations:ElementTypeSetConfiguration>


### PR DESCRIPTION
I believe that some of your current problems are caused by this missing extension

<extension point="org.eclipse.uml2.uml.generated_package">
     <profile uri="http://www.eclipse.org/papyrus/Anatomy"
          location="pathmap://ANATOMY_PROFILE/anatomy.profile.uml#_pWlLsBzSEeaUCNZJoDLoVw"/>
 </extension> 

=> you can add it and try.

This is an example on how I would proceed to create a "WorkItem"
(I suppose that a WorkItem is a WorkPart typed with WorkItem)
- init the element types from the profile model:
  - generate 2 files using Developer Tool:
  -  open the profile Right Click on the root element > Generate Tooling...
    => postfix the 2 files by -gen
- set the specialisation of WorkItem to WorkPart
- set the value in the helper
